### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,40 +6,40 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Skribot		KEYWORD1	MainRobot
+Skribot	KEYWORD1	MainRobot
 ServoRotor	KEYWORD1	MainRobot
 DistSensor	KEYWORD1	MainRobot
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-AddRotor				KEYWORD2
-AddDistSensor			KEYWORD2
-ReadDistSensor			KEYWORD2
-AddLineSensor			KEYWORD2
-AddDCRotor				KEYWORD2
-ReadLineSensor			KEYWORD2
-AddScope				KEYWORD2
-AddLED					KEYWORD2
-AddClaw					KEYWORD2
+AddRotor	KEYWORD2
+AddDistSensor	KEYWORD2
+ReadDistSensor	KEYWORD2
+AddLineSensor	KEYWORD2
+AddDCRotor	KEYWORD2
+ReadLineSensor	KEYWORD2
+AddScope	KEYWORD2
+AddLED	KEYWORD2
+AddClaw	KEYWORD2
 Configure_Connections	KEYWORD2
-Move					KEYWORD2
-Stop					KEYWORD2
-TurnLeft				KEYWORD2
-TurnRight				KEYWORD2
-FaceLeft				KEYWORD2
-FaceRight				KEYWORD2
-TurnLEDOn				KEYWORD2
-TurnLEDOff				KEYWORD2
-MoveForward				KEYWORD2
-MoveBack				KEYWORD2
-GetScopeDistance		KEYWORD2
-SetScopeAngle			KEYWORD2
-SetSpeed				KEYWORD2
-CloseClaw				KEYWORD2
-OpenClaw				KEYWORD2
-Pick_Up					KEYWORD2
-Put_Down				KEYWORD2
+Move	KEYWORD2
+Stop	KEYWORD2
+TurnLeft	KEYWORD2
+TurnRight	KEYWORD2
+FaceLeft	KEYWORD2
+FaceRight	KEYWORD2
+TurnLEDOn	KEYWORD2
+TurnLEDOff	KEYWORD2
+MoveForward	KEYWORD2
+MoveBack	KEYWORD2
+GetScopeDistance	KEYWORD2
+SetScopeAngle	KEYWORD2
+SetSpeed	KEYWORD2
+CloseClaw	KEYWORD2
+OpenClaw	KEYWORD2
+Pick_Up	KEYWORD2
+Put_Down	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords